### PR TITLE
Enforce authentication of registrar of all HTTPS requests involved during LDevID enrollment

### DIFF
--- a/lib/pledge.rb
+++ b/lib/pledge.rb
@@ -145,7 +145,7 @@ class Pledge
     voucher_pinned_name = pinned_domain_cert.try(:subject).try(:to_s)
     voucher_pinned_name ||= "unknown"
     puts "pinned-domain-cert in voucher connects to #{voucher_pinned_name}"
-    puts "TLS peer cert:               #{handler.peer_cert.subject.to_s}"
+    puts "TLS peer cert:                            #{handler.peer_cert.subject.to_s}"
 
     peer_cert = handler.try(:peer_cert)
     unless handler

--- a/lib/tasks/pledge.rake
+++ b/lib/tasks/pledge.rake
@@ -86,7 +86,12 @@ namespace :reach do
       puts "Failed to validate voucher"
       exit 1
     end
-    client.enroll(true)
+
+    # extract the pinned-domain-cert from the validated voucher
+    # so that it can be used as local trust anchor
+    pinned_domain_cert = voucher.try(:pinnedDomainCert)
+
+    client.enroll(true, pinned_domain_cert)
   end
 
   # do an EST simpleenroll with a trusted IDevID


### PR DESCRIPTION
Problem Statement:
Enrolling for an LDevID involves multiple HTTP(S) requests from pledge to registrar:
1. Request voucher
2. Request CSR attributes 
3. Request LDevID certificate
The current implementation fetches a voucher and validates it, but then uses new TLS sessions for requests 2 and 3, leading to a MitM vulnerability.

Solution:
All these requests must be to the same legitimate registrar, i.e. the JRC that is authenticated by the pinned-domain-certificate inside a valid voucher. Therefore, once a voucher has been obtained and successfully validated, the pinned-domain-cert has to be extracted and used as ground truth for validation of the TLS peer certificate (JRC server cert) of all subsequent HTTP(S) requests. While enforcing a persistent TLS session for all requests 1-to-3 is desirable, explicitly comparing the TLS peer cert with the pinned-domain-cert for each request is "belt-and-suspenders"-secure and does not contradict future developments towards reusing the same TLS session for all requests.  